### PR TITLE
264_enc: apply encode base class for AVC SVC-T

### DIFF
--- a/common/nalreader.cpp
+++ b/common/nalreader.cpp
@@ -45,6 +45,7 @@ bool NalReader::read(const uint8_t*& nal, int32_t& nalSize)
     const uint8_t* nalEnd;
     if (m_asWhole) {
         nalEnd = m_end;
+        m_next = m_end;
     } else {
         nalEnd = searchNalStart();
     }

--- a/common/utils_unittest.cpp
+++ b/common/utils_unittest.cpp
@@ -129,6 +129,15 @@ UTILS_TEST(guessResolutionOverflow) {
     EXPECT_FALSE(guessResolution(sstream.str().c_str(), w, h));
     EXPECT_EQ(w, 0);
     EXPECT_EQ(h, 0);
+
+    sstream.str("");
+    sstream << long(std::numeric_limits<int>::max()) * 2 + 3
+            << "x"
+            << long(std::numeric_limits<int>::max()) * 3 + 2;
+
+    EXPECT_FALSE(guessResolution(sstream.str().c_str(), w, h));
+    EXPECT_EQ(w, 0);
+    EXPECT_EQ(h, 0);
 }
 
 struct BppEntry {

--- a/encoder/vaapiencoder_base.cpp
+++ b/encoder/vaapiencoder_base.cpp
@@ -669,6 +669,7 @@ YamiStatus VaapiEncoderBase::getOutput(VideoEncOutputBuffer* outBuffer, bool wit
         return ret;
 
     outBuffer->timeStamp = picture->m_timeStamp;
+    outBuffer->temporalID = picture->m_temporalID;
     checkCodecData(outBuffer);
     return YAMI_SUCCESS;
 }
@@ -697,6 +698,7 @@ YamiStatus VaapiEncoderBase::getOutput(VideoEncOutputBuffer* outBuffer, VideoEnc
     if (data)
         memcpy(MVBuffer->data, data, mappedSize);
     outBuffer->timeStamp = picture->m_timeStamp;
+    outBuffer->temporalID = picture->m_temporalID;
     checkCodecData(outBuffer);
     return YAMI_SUCCESS;
 }

--- a/encoder/vaapiencoder_base.h
+++ b/encoder/vaapiencoder_base.h
@@ -100,9 +100,11 @@ protected:
 
     //rate control related things
     void fill(VAEncMiscParameterHRD*) const ;
-    void fill(VAEncMiscParameterRateControl*) const ;
-    void fill(VAEncMiscParameterFrameRate*) const;
+    void fill(VAEncMiscParameterRateControl*, uint32_t temporalID = 0) const;
+    void fill(VAEncMiscParameterFrameRate*, uint32_t temporalID) const;
     virtual bool ensureMiscParams(VaapiEncPicture*);
+    bool ensureRateControl(VaapiEncPicture* picture, uint32_t temporalID);
+    bool ensureFrameRate(VaapiEncPicture* picture, uint32_t temporalID);
 
     //properties
     VideoProfile profile() const;
@@ -181,6 +183,7 @@ protected:
     uint32_t m_vaVideoParamQualityLevel;
     uint32_t m_maxOutputBuffer; // max count of frames are encoding in parallel, it hurts performance when m_maxOutputBuffer is too big.
     uint32_t m_maxCodedbufSize;
+    VideoFrameRate m_svctFrameRate[TEMPORAL_LAYER_LENGTH_MAX];
 
 private:
     bool initVA();

--- a/encoder/vaapiencoder_h264.cpp
+++ b/encoder/vaapiencoder_h264.cpp
@@ -860,7 +860,6 @@ VaapiEncoderH264::VaapiEncoderH264()
     m_videoParamAVC.enableDeblockFilter = true;
     m_videoParamAVC.deblockAlphaOffsetDiv2 = 2;
     m_videoParamAVC.deblockBetaOffsetDiv2 = 2;
-    m_videoParamAVC.temporalLayerNum = 1;
     m_videoParamAVC.priorityId = 0;
     m_videoParamAVC.enablePrefixNalUnit = false;
     m_maxOutputBuffer = H264_MIN_TEMPORAL_GOP;

--- a/encoder/vaapiencoder_h264.h
+++ b/encoder/vaapiencoder_h264.h
@@ -68,8 +68,6 @@ private:
 #if VA_CHECK_VERSION(0, 39, 4)
     void fill(VAEncMiscParameterTemporalLayerStructure*) const;
 #endif
-    void fill(VAEncMiscParameterRateControl*, uint32_t temporalId) const;
-    void fill(VAEncMiscParameterFrameRate*, uint32_t temporalId) const;
     bool fill(VAEncSequenceParameterBufferH264*) const;
     bool fill(VAEncPictureParameterBufferH264*, const PicturePtr&, const SurfacePtr&) const ;
     bool ensureSequenceHeader(const PicturePtr&, const VAEncSequenceParameterBufferH264* const);

--- a/encoder/vaapiencoder_vp8.h
+++ b/encoder/vaapiencoder_vp8.h
@@ -26,11 +26,14 @@
 namespace YamiMediaCodec{
 
 class VaapiEncPictureVP8;
+class Vp8Encoder;
+struct RefFlags;
 class VaapiEncoderVP8 : public VaapiEncoderBase {
 public:
     //shortcuts, It's intended to elimilate codec diffrence
     //to make template for other codec implelmentation.
     typedef SharedPtr<VaapiEncPictureVP8> PicturePtr;
+    typedef SharedPtr<Vp8Encoder> Vp8EncoderPtr;
     typedef SurfacePtr ReferencePtr;
 
     VaapiEncoderVP8();
@@ -52,12 +55,15 @@ private:
 
     YamiStatus encodePicture(const PicturePtr&);
     bool fill(VAEncSequenceParameterBufferVP8*) const;
-    bool fill(VAEncPictureParameterBufferVP8*, const PicturePtr&, const SurfacePtr&) const ;
+    void fill(VAEncPictureParameterBufferVP8*, const RefFlags&) const;
+    bool fill(VAEncPictureParameterBufferVP8*, const PicturePtr&, const SurfacePtr&, RefFlags&) const;
     bool fill(VAQMatrixBufferVP8* qMatrix) const;
     bool ensureSequence(const PicturePtr&);
-    bool ensurePicture (const PicturePtr&, const SurfacePtr&);
+    bool ensurePicture (const PicturePtr&, const SurfacePtr&, RefFlags&);
     bool ensureQMatrix (const PicturePtr&);
-    bool referenceListUpdate (const PicturePtr&, const SurfacePtr&);
+    const SurfacePtr& referenceUpdate(const SurfacePtr& to, const SurfacePtr& from,
+        const SurfacePtr& recon, bool refresh, uint32_t copy) const;
+    bool referenceListUpdate (const PicturePtr&, const SurfacePtr&, const RefFlags&);
 
     void resetParams();
 
@@ -69,8 +75,10 @@ private:
 
     int m_qIndex;
 
-    typedef std::deque<SurfacePtr> ReferenceQueue;
-    std::deque<SurfacePtr> m_reference;
+    SurfacePtr m_last;
+    SurfacePtr m_golden;
+    SurfacePtr m_alt;
+    Vp8EncoderPtr m_encoder;
 
     /**
      * VaapiEncoderFactory registration result. This encoder is registered in

--- a/encoder/vaapiencoder_vp8.h
+++ b/encoder/vaapiencoder_vp8.h
@@ -48,6 +48,7 @@ public:
 
 protected:
     virtual YamiStatus doEncode(const SurfacePtr&, uint64_t timeStamp, bool forceKeyFrame = false);
+    virtual bool ensureMiscParams(VaapiEncPicture*);
 
 private:
     friend class FactoryTest<IVideoEncoder, VaapiEncoderVP8>;

--- a/encoder/vaapiencpicture.cpp
+++ b/encoder/vaapiencpicture.cpp
@@ -30,7 +30,8 @@ namespace YamiMediaCodec{
 VaapiEncPicture::VaapiEncPicture(const ContextPtr& context,
                                  const SurfacePtr & surface,
                                  int64_t timeStamp)
-:VaapiPicture(context, surface, timeStamp)
+: VaapiPicture(context, surface, timeStamp)
+, m_temporalID(0)
 {
 }
 

--- a/encoder/vaapiencpicture.h
+++ b/encoder/vaapiencpicture.h
@@ -63,6 +63,7 @@ class VaapiEncPicture:public VaapiPicture {
 #endif
 
     CodedBufferPtr m_codedBuffer;
+    uint8_t m_temporalID;
 
   private:
     bool doRender();

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -172,7 +172,6 @@ typedef struct VideoRateControlParams {
     uint32_t disableBitsStuffing;
     int8_t diffQPIP;// P frame qp minus initQP
     int8_t diffQPIB;// B frame qp minus initQP
-    uint32_t layerBitRate[32]; // specify each scalable layer bitrate
 }VideoRateControlParams;
 
 typedef struct SliceNum {
@@ -243,7 +242,6 @@ typedef struct VideoParamsAVC {
     bool  enableDeblockFilter;
     int8_t deblockAlphaOffsetDiv2; //same as slice_alpha_c0_offset_div2 defined in h264 spec 7.4.3
     int8_t deblockBetaOffsetDiv2; //same as slice_beta_offset_div2 defined in h264 spec 7.4.3
-    uint32_t temporalLayerNum;
     uint32_t priorityId;
     // enable prefix NAL unit defined as h264 spec G.3.42.
     // It can be used for h264 simucast or svc-t encoding.

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -100,6 +100,7 @@ typedef struct VideoEncOutputBuffer {
     uint32_t remainingSize;
     uint32_t flag;                   //Key frame, Codec Data etc
     VideoOutputFormat format;   //output format
+    uint8_t temporalID;			//output temporal id for SVCT encoder
     uint64_t timeStamp;         //reserved
 }VideoEncOutputBuffer;
 

--- a/interface/VideoEncoderDefs.h
+++ b/interface/VideoEncoderDefs.h
@@ -91,6 +91,7 @@ typedef enum {
 #define VIDEO_PARAMS_QUALITYLEVEL_NONE 0
 #define VIDEO_PARAMS_QUALITYLEVEL_MIN 1
 #define VIDEO_PARAMS_QUALITYLEVEL_MAX 7
+#define TEMPORAL_LAYER_LENGTH_MAX 32
 
 typedef struct VideoEncOutputBuffer {
     uint8_t *data;
@@ -151,6 +152,11 @@ typedef struct VideoFrameRate {
     uint32_t frameRateNum;
     uint32_t frameRateDenom;
 }VideoFrameRate;
+typedef struct VideoTemproalLayers {
+    //bitrate of the highest layer is VideoParamsCommon.rcParams.bitRate
+    uint8_t numLayersMinus1;
+    uint32_t bitRate[TEMPORAL_LAYER_LENGTH_MAX];
+} VideoTemproalLayers;
 
 typedef struct VideoResolution {
     uint32_t width;
@@ -213,6 +219,7 @@ typedef struct VideoParamsCommon {
     uint8_t level;
     VideoResolution resolution;
     VideoFrameRate frameRate;
+    VideoTemproalLayers temporalLayers;
     uint32_t intraPeriod;
     uint32_t ipPeriod;
     uint32_t numRefFrames;


### PR DESCRIPTION
Calling base class's functions to set framerate and bitrate for
AVC SVC-T encoding.

Signed-off-by: wudping <dongpingx.wu@intel.com>